### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/4](https://github.com/secwexen/aappmart/security/code-scanning/4)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in this workflow to the minimum necessary. This job only needs to check out the repository and run local build/publish commands; it does not need to write to the repository or interact with issues/PRs. Therefore, `contents: read` is sufficient.

The most straightforward, non‑disruptive fix is:

- Add a `permissions:` block at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs in this workflow.
- Set `contents: read` as recommended by the CodeQL message.

Concretely, in `.github/workflows/publish.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Publish to PyPI` line and the `on:` block (lines 1 and 3 in the provided snippet). No other steps, secrets, or actions need to be changed, and no additional imports or tools are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
