### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/5](https://github.com/secwexen/aappmart/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level or within the specific job) that restricts the `GITHUB_TOKEN` to the minimal required scopes. For this testing workflow, the steps only read repository contents (via `actions/checkout`) and do not need any write permissions or special scopes such as `pull-requests` or `issues`. Therefore, setting `contents: read` is sufficient and conservative.

The single best way to fix this without changing functionality is to add a top‑level `permissions` block right after the `name:` declaration, so it applies to all jobs in the workflow. Concretely, in `.github/workflows/tests.yml`, between line 1 (`name: Run Tests`) and line 3 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed because this is a GitHub Actions workflow configuration change only. All existing steps (checkout, Python setup, installing dependencies, running tests) will continue to work with a read‑only `contents` permission, and the CodeQL warning about missing permissions will be resolved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
