### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/3](https://github.com/secwexen/aappmart/security/code-scanning/3)

In general, to fix this issue you should explicitly define a `permissions` block in the workflow (at the root or per job) to limit the `GITHUB_TOKEN` to the minimal scopes required. For a pure CI workflow that only checks out code and runs local tests, `contents: read` is typically sufficient; no write permissions are needed.

For this specific file, the best fix without changing existing functionality is to add a root-level `permissions` block just after the `on:` section, before `jobs:`. This will apply to all jobs in the workflow (currently only `build`) and restrict `GITHUB_TOKEN` to read-only access to repository contents. No additional imports or methods are required, since this is a YAML configuration-only change.

Concretely, edit `.github/workflows/python-package.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (`pull_request` branches) and the `jobs:` key. The rest of the workflow, including all steps, remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
