### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/2](https://github.com/secwexen/aappmart/security/code-scanning/2)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since this lint job only needs to read the repository contents (for checkout and running pylint), we can safely restrict permissions to `contents: read`. We can apply this at the job level for the `lint` job, which is also the CodeQL-highlighted area, without changing any existing functionality.

Concretely, in `.github/workflows/lint.yml`, add a `permissions:` block under the `lint` job, at the same indentation level as `runs-on`. For example, insert:

```yaml
    permissions:
      contents: read
```

between the `lint:` job header and the `runs-on:` line (or between `runs-on:` and `steps:`; both are valid, but placing it alongside the other job keys keeps it clear). No additional methods, imports, or configuration are required; this is purely a YAML workflow change and does not alter how the steps execute, only the scope of the `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
