### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,8 @@
 name: Pylint
 
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/1](https://github.com/secwexen/aappmart/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block either at the workflow root (applies to all jobs) or within the specific job, restricting the `GITHUB_TOKEN` to the minimal necessary scopes. Since this workflow only checks out code and runs pylint, it only needs read access to repository contents.

The best minimal change without altering functionality is to add a `permissions:` block at the workflow root, just under the `on:` definition, setting `contents: read`. This will apply to the `build` job (and any future jobs that don’t override permissions) and ensure the `GITHUB_TOKEN` cannot perform write operations. No additional imports, methods, or other definitions are needed; this is purely a YAML configuration change in `.github/workflows/pylint.yml`.

Concretely:
- Edit `.github/workflows/pylint.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after line 3 (`on: [push]`) and before line 5 (`jobs:`). Indentation should be at the root level (no leading spaces), matching the style of `name:` and `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
