### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,9 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/6](https://github.com/secwexen/aappmart/security/code-scanning/6)

In general, the fix is to explicitly set `permissions` for the workflow or individual jobs so that the `GITHUB_TOKEN` has only the minimal scopes required. For a read-only security scanning workflow that checks out code and uploads SARIF results, `contents: read` is typically sufficient; the CodeQL SARIF upload action uses the token to associate results with the repo but does not need write permissions to repository contents.

The best fix here without changing behavior is to add a root-level `permissions:` block between the `name:` and `on:` lines, setting `contents: read`. This applies to all jobs (including `MSDO`) that don’t define their own permissions and directly addresses CodeQL’s recommendation (“using the following as a minimal starting point: {contents: read}”). No other files or imports are involved, and no existing steps need to be modified.

Concretely:
- Edit `.github/workflows/defender-for-devops.yml`.
- After line 19 (`name: "Microsoft Defender For Devops"`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
