### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,5 +1,8 @@
 name: Makefile CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aappmart/security/code-scanning/7](https://github.com/secwexen/aappmart/security/code-scanning/7)

In general, the fix is to explicitly declare a `permissions` block in the workflow (or at the job level) that grants only the minimal scopes needed. For a typical CI build that only checks out code and runs `make`/tests without interacting with GitHub APIs in a write-capable way, `contents: read` is sufficient and matches the minimal recommendation from CodeQL.

The best targeted fix here is to add a workflow-level `permissions` block near the top of `.github/workflows/makefile.yml`, just after the `name` line and before the `on:` trigger. This will apply to all jobs in the workflow (currently only `build`) and avoids needing to repeat configuration. The block should set `contents: read`, which is adequate for `actions/checkout@v4` and typical build steps. No other functionality in the provided snippet depends on broader or write permissions, so this change should not alter behavior while resolving the CodeQL finding.

Concretely: in `.github/workflows/makefile.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Makefile CI`). No additional imports, methods, or other definitions are required because this is purely a YAML configuration change within the GitHub Actions workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
