### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "develop" ]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aapp-mart/security/code-scanning/9](https://github.com/secwexen/aapp-mart/security/code-scanning/9)

In general, the fix is to explicitly declare a `permissions` block that narrows the `GITHUB_TOKEN` to the least privileges needed. For this workflow, the steps only check out code, set up Python, install dependencies, run tests, and upload an artifact. None of these require write access to repository contents, issues, or pull requests. Therefore, setting `permissions: contents: read` is an appropriate minimal scope. Defining this at the workflow root ensures all jobs inherit it; defining it at the job level scopes it to that job only. Either is acceptable, but putting it at the root is clearer if all jobs share the same needs.

The single best fix with minimal impact is: add a `permissions` block at the top level, between the `name:` and `on:` keys in `.github/workflows/test.yml`, with `contents: read`. This documents the workflow’s needs and ensures that if repository/org defaults change in the future, this workflow will still only get read access to repository contents. No imports, additional methods, or other code changes are required; only the YAML configuration is updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
