### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,5 +1,8 @@
 name: Python Package using Conda
 
+permissions:
+  contents: read
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aapp-mart/security/code-scanning/10](https://github.com/secwexen/aapp-mart/security/code-scanning/10)

In general, the fix is to explicitly declare the least-privilege `permissions` for the `GITHUB_TOKEN` used by this workflow. Since this workflow only needs to read repository contents to check out code, a minimal and appropriate configuration is `contents: read`. Declaring this at the workflow root applies to all jobs that do not override it.

The best single fix without changing existing functionality is to add a `permissions` block at the top level of `.github/workflows/python-package-conda.yml`, alongside `name` and `on`. Insert:

```yaml
permissions:
  contents: read
```

between the `name` and `on` keys (or just above `jobs:`; both are valid, but top-level is clearer and applies to all jobs). No imports, methods, or additional definitions are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
