### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,9 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "develop", "feature/*", "gh-pages", "hotfix/*", "release/*" ]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aapp-mart/security/code-scanning/6](https://github.com/secwexen/aapp-mart/security/code-scanning/6)

To fix the problem, add an explicit `permissions:` block that grants only the minimal scopes needed for this workflow. Since the job only checks out the repository, sets up .NET, runs the Microsoft Security DevOps action, and uploads SARIF results to the Security tab, it typically only needs read access to repository contents and possibly security-related scopes handled by GitHub’s internal mechanisms. A safe minimal starting point is `contents: read` at the workflow level, which will apply to all jobs (here, just `MSDO`).

The best fix without changing functionality is to add a root-level `permissions:` block just under the `name:` (before `on:`), with `contents: read`. This avoids touching any job logic. If later you discover the workflow needs additional scopes (for example, `security-events: write`), they can be added to this block, but for now we’ll follow the CodeQL suggestion of `contents: read` as a minimal baseline. Concretely, edit `.github/workflows/defender-for-devops.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 19 (`name: "Microsoft Defender For Devops"`). No imports or additional methods are needed, since this is purely workflow configuration in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
