### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aapp-mart/security/code-scanning/11](https://github.com/secwexen/aapp-mart/security/code-scanning/11)

In general, the fix is to add an explicit `permissions` block to the workflow or to the individual job so that the `GITHUB_TOKEN` is limited to the minimum scopes required. This prevents inheriting potentially broader repository/organization defaults and documents what the workflow needs.

For this specific workflow, the job `update_release_draft` uses `release-drafter/release-drafter@v6` to maintain GitHub Releases based on merged pull requests. Release Drafter typically needs to read repository contents and pull requests/issues, and to write releases. A safe, common configuration for this action is:
- `contents: write` (to create/update releases),
- `pull-requests: read` (to read PR metadata),
- optionally `issues: read` if your configuration uses issues as well.

To avoid changing existing functionality (so Release Drafter can still create/update releases), we should not restrict `contents` to `read`; instead, we should grant `contents: write` at the job level. We will therefore add a `permissions` block under the `update_release_draft` job (just above `runs-on: ubuntu-latest`) in `.github/workflows/release-drafter.yml`:

```yaml
jobs:
  update_release_draft:
    permissions:
      contents: write
      pull-requests: read
    runs-on: ubuntu-latest
    ...
```

No new imports or other files are needed; only this workflow YAML needs updating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
