### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       digests: ${{ steps.hash.outputs.digests }}


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aapp-mart/security/code-scanning/13](https://github.com/secwexen/aapp-mart/security/code-scanning/13)

In general, the fix is to add an explicit `permissions` section to the workflow (either at the root or per job) to ensure the `GITHUB_TOKEN` has only the minimal scopes required. For the `build` job here, it only needs to read repository contents to check out the code, so `contents: read` is sufficient.

The best fix with minimal impact is to add a `permissions` block directly under the `build` job, before `runs-on`. This confines the change to that specific job and does not affect the already-correct `permissions` block on the `provenance` job. Concretely, in `.github/workflows/generator-generic-ossf-slsa3-publish.yml`, on the `build` job definition (line 20 onwards), insert:

```yaml
    permissions:
      contents: read
```

between `build:` and `runs-on: ubuntu-latest`. No imports or additional methods are needed, as this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
