### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/aapp-mart/security/code-scanning/8](https://github.com/secwexen/aapp-mart/security/code-scanning/8)

To fix the problem, add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges necessary. For this workflow, the steps only check out the code and build a Docker image locally, so `contents: read` at the workflow or job level is sufficient.

The best change with minimal impact is to define `permissions: contents: read` at the root level of the workflow, directly under the `name` (or at the same indentation level as `on:`). This will apply to all jobs (currently only `build`) without altering their behavior, since reading repository contents is already required and allowed. No imports or additional methods are needed, as this is purely a YAML configuration change.

Specifically, in `.github/workflows/docker-image.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Docker Image CI`) and before the `on:` block (line 3). No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
